### PR TITLE
Pass Model object into custom class

### DIFF
--- a/Script for creating Aggregated Measures for selected columns with bug.csx
+++ b/Script for creating Aggregated Measures for selected columns with bug.csx
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 // Custom form for selecting columns and aggregation types with search functionality
 public class SelectionForm : Form
 {
+    public Model Model;
     public Label ColumnsLabel;
     public Label AggregationsLabel;
     public CheckedListBox AggregationsCheckedListBox;
@@ -18,8 +19,9 @@ public class SelectionForm : Form
     public CheckBox ShowHiddenColumnsCheckBox;
     public Dictionary<string, string[]> columnsByTableMain;
 
-    public SelectionForm(string[] tableNames, Dictionary<string, string[]> columnsByTable)
+    public SelectionForm(string[] tableNames, Dictionary<string, string[]> columnsByTable, Model model)
     {
+        Model = model;
         columnsByTableMain = columnsByTable;
 
         Text = "Select Columns and Aggregation Types";
@@ -213,7 +215,7 @@ if (Model != null)
             .ToDictionary(g => g.Key, g => g.Select(col => col.Name).ToArray());
 
         // Show the custom form to select columns and aggregation types
-        var form = new SelectionForm(columnsByTable.Keys.ToArray(), columnsByTable);
+        var form = new SelectionForm(columnsByTable.Keys.ToArray(), columnsByTable, Model);
         if (form.ShowDialog() == DialogResult.OK)
         {
             var selectedColumns = form.GetSelectedColumns();


### PR DESCRIPTION
Unfortunately, TE3 macro compilation works a bit differently than script compilation. The former does not allow access to global objects (such as `Model` and `Selected`) inside the scope of a custom class. Because you attempt to access the global `Model` object in [this line](https://github.com/revanth-ar/T3-Scripts/blob/61f2a45b7edc989b0410fffde270104807460392/Script%20for%20creating%20Aggregated%20Measures%20for%20selected%20columns%20with%20bug.csx#L183), the script cannot be saved as a macro.

This PR fixes this, by passing in the `Model` object to the custom class, so that it is accessible as a member inside the class.